### PR TITLE
fix: correct the onboard EEPROM compatible

### DIFF
--- a/arch/arm64/boot/dts/ti/k3-am67a-t3-gem-o1.dts
+++ b/arch/arm64/boot/dts/ti/k3-am67a-t3-gem-o1.dts
@@ -998,7 +998,7 @@
 	};
 
 	eeprom@51 {
-		compatible = "atmel,24c32";
+		compatible = "atmel,24c512";
 		vcc-supply = <&vdd_3v3>;
 		reg = <0x51>;
 	};


### PR DESCRIPTION
The onboard EEPROM is an AT24C512C with 64 KiB capacity. Describe it as atmel,24c512 so the full capacity is accessible.

Verified on hardware by accessing offset 0x2000 without wrapping to offset 0. 