### PR TITLE
fix: limit ICM-20948 SPI frequency to 7 MHz

### DIFF
--- a/arch/arm64/boot/dts/ti/k3-am67a-t3-gem-o1.dts
+++ b/arch/arm64/boot/dts/ti/k3-am67a-t3-gem-o1.dts
@@ -893,7 +893,7 @@
 	};
 
 	imu@3 {
-		spi-max-frequency = <50000000>;
+		spi-max-frequency = <7000000>;
 		reg = <3>;
 		compatible = "invensense,icm20948-spidev";
 	};


### PR DESCRIPTION
The ICM-20948 datasheet specifies 7 MHz as the maximum SPI clock frequency.