### PR TITLE
fix: use the verified T3 PMIC address

### DIFF
--- a/arch/arm64/boot/dts/ti/k3-am67a-t3-gem-o1.dts
+++ b/arch/arm64/boot/dts/ti/k3-am67a-t3-gem-o1.dts
@@ -924,9 +924,9 @@
 	bootph-all;
 	status = "okay";
 
-	tps65219: pmic@40 {
+	tps65219: pmic@30 {
 		compatible = "ti,tps65219";
-		reg = <0x40>;
+		reg = <0x30>;
 		buck1-supply = <&vsys_5v0>;
 		buck2-supply = <&vsys_5v0>;
 		buck3-supply = <&vsys_5v0>;


### PR DESCRIPTION
Describe the TPS65219 at 0x30, matching its live I2C_ADDRESS_REG value and the vendor U-Boot device tree.