### PR TITLE
arm64: dts: k3-am67a-t3-gem-o1: fix TPS65219 PMIC I2C address

### DIFF
--- a/arch/arm64/boot/dts/ti/k3-am67a-t3-gem-o1.dts
+++ b/arch/arm64/boot/dts/ti/k3-am67a-t3-gem-o1.dts
@@ -924,9 +924,9 @@
 	bootph-all;
 	status = "okay";
 
-	tps65219: pmic@40 {
+	tps65219: pmic@30 {
 		compatible = "ti,tps65219";
-		reg = <0x40>;
+		reg = <0x30>;
 		buck1-supply = <&vsys_5v0>;
 		buck2-supply = <&vsys_5v0>;
 		buck3-supply = <&vsys_5v0>;


### PR DESCRIPTION
The TPS65219 on this board responds at I2C 0x30, not 0x40 (NVM_ID=0x0a, MFP_2_CONFIG=0xdc). At 0x40 the VOUT registers all read zero, decoding to 600000 uV and 1200000 uV, so the regulator core logged six "Bringing <n>uV into <min>-<max>uV" corrections at probe.